### PR TITLE
Only invoke the "not found route" if it is actually known

### DIFF
--- a/router-mixin/router-mixin.js
+++ b/router-mixin/router-mixin.js
@@ -91,9 +91,11 @@ export let routerMixin = (superclass) => class extends superclass {
                 route.callback && route.callback(route.name, route.params, route.query, route.data)
                 callback(route.name, route.params, route.query, route.data);
             }
-        } else {
+        } else if (notFoundRoute) {
             notFoundRoute.callback && notFoundRoute.callback(notFoundRoute.name, {}, {}, {})
             callback(notFoundRoute.name, {}, {}, {});
+        } else {
+            callback('not-found', {}, {});
         }
 
         if (super.router) super.router();

--- a/router/router.js
+++ b/router/router.js
@@ -59,8 +59,10 @@ export function router(routes, callback) {
             route.callback && route.callback(route.name, route.params, route.query, route.data)
             callback(route.name, route.params, route.query, route.data);
         }
-    } else {
+    } else if (notFoundRoute) {
         notFoundRoute.callback && notFoundRoute.callback(notFoundRoute.name, {}, {}, {})
         callback(notFoundRoute.name, {}, {}, {});
+    } else {
+        callback('not-found', {}, {});
     }
 }


### PR DESCRIPTION
The examples seem to always have a "home" route, which always matches. When this is not given, and there is no `notFoundRoute`, one gets an error like this:
~~~~
TypeError: Cannot read property 'callback' of undefined
router.js:50
    at router (/home/andreas/project/collaborne-polaris-analytics-app/node_modules/lit-element-router/router.js:50:20)
~~~~

Fix that by checking for that case, and invoking the global callback with an argument of `'not-found'` in that case.