### PR TITLE
Fix and simplify the handling of guards

### DIFF
--- a/router-mixin/router-mixin.js
+++ b/router-mixin/router-mixin.js
@@ -69,10 +69,9 @@ export let routerMixin = (superclass) => class extends superclass {
             if (route.guard && typeof route.guard === 'function') {
                 const guard = route.guard();
 
-                if (guard instanceof Promise) {
-
-                    guard.then((resolved) => {
-                        if (resolved) {
+                Promise.resolve(guard)
+                    .then((allowed) => {
+                        if (allowed) {
                             route.callback && route.callback(route.name, route.params, route.query, route.data)
                             callback(route.name, route.params, route.query, route.data);
                         } else {
@@ -80,13 +79,6 @@ export let routerMixin = (superclass) => class extends superclass {
                             callback('not-authorized', {}, {}, {});
                         }
                     })
-                } else if (typeof guard === 'boolean') {
-                    route.callback && route.callback(route.name, route.params, route.query, route.data)
-                    callback(route.name, route.params, route.query, route.data);
-                } else {
-                    route.callback && route.callback('not-authorized', route.params, route.query, route.data)
-                    callback('not-authorized', {}, {}, {});
-                }
             } else {
                 route.callback && route.callback(route.name, route.params, route.query, route.data)
                 callback(route.name, route.params, route.query, route.data);

--- a/router/router.js
+++ b/router/router.js
@@ -37,10 +37,9 @@ export function router(routes, callback) {
         if (route.guard && typeof route.guard === 'function') {
             const guard = route.guard();
 
-            if (guard instanceof Promise) {
-
-                guard.then((resolved) => {
-                    if (resolved) {
+            Promise.resolve(guard)
+                .then((allowed) => {
+                    if (allowed) {
                         route.callback && route.callback(route.name, route.params, route.query, route.data)
                         callback(route.name, route.params, route.query, route.data);
                     } else {
@@ -48,13 +47,6 @@ export function router(routes, callback) {
                         callback('not-authorized', {}, {}, {});
                     }
                 })
-            } else if (typeof guard === 'boolean') {
-                route.callback && route.callback(route.name, route.params, route.query, route.data)
-                callback(route.name, route.params, route.query, route.data);
-            } else {
-                route.callback && route.callback('not-authorized', route.params, route.query, route.data)
-                callback('not-authorized', {}, {}, {});
-            }
         } else {
             route.callback && route.callback(route.name, route.params, route.query, route.data)
             callback(route.name, route.params, route.query, route.data);


### PR DESCRIPTION
* Don't try to check whether something is a promise, just use `Promise.resolve` to resolve
  whatever we have
* Properly check the return value of the guard, not whether it just happens to be a boolean
  (which may be either true or false ...)