### PR TITLE
Add CSS "all: unset" fallback for Edge

### DIFF
--- a/router/router-link.js
+++ b/router/router-link.js
@@ -24,6 +24,10 @@ export class RouterLink extends LitElement {
                 a {
                     all: unset;
                     display: contents;
+                    
+                    /*Fallback for Edge*/
+                    text-decoration: unset;
+                    color: unset;
                 }
             </style>
             <a href='${this.href}'>


### PR DESCRIPTION
All router-links in Microsoft Edge have a default link style because Edge does not implement the CSS "all" property :(