### PR TITLE
Add `types` field pointing to lit-element-router.d.ts

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "lit-element-router",
   "version": "2.0.3",
   "main": "lit-element-router.js",
+  "types": "lit-element-router.d.ts",
   "scripts": {
     "test": "nyc mocha --require @babel/register './{,!(node_modules)/**/}*.test.js' --exit",
     "report": "npm test && nyc report --reporter=text-lcov | COVERALLS_REPO_TOKEN=$COVERALLS_TOKEN coveralls",


### PR DESCRIPTION
This is recommended in the TS documentation: https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html#including-declarations-in-your-npm-package

...and will enable SkyPack to work correctly as described here: https://docs.skypack.dev/package-authors/package-checks#types