### PR TITLE
#44 Add support for baseURI

### DIFF
--- a/lit-element-router.js
+++ b/lit-element-router.js
@@ -5,13 +5,14 @@ export function router(base) {
         static get properties() {
             return {
                 route: { type: String, reflect: true, attribute: 'route' },
-                canceled: { type: Boolean }
+                canceled: { type: Boolean },
+                basePath: { type: String, attribute: "base-path"}
             };
         }
 
         constructor(...args) {
             super(...args);
-
+            this.basePath = document.baseURI.substring(0, document.baseURI.lastIndexOf('/')) + '/';
             this.route = '';
             this.canceled = false;
         }
@@ -39,7 +40,7 @@ export function router(base) {
         routing(routes, callback) {
             this.canceled = true;
 
-            const uri = decodeURI(window.location.pathname);
+            const uri = decodeURI((window.location.origin + window.location.pathname).replace(this.basePath, ''));
             const querystring = decodeURI(window.location.search);
 
             let notFoundRoute = routes.filter(route => route.pattern === '*')[0];


### PR DESCRIPTION
This PR adds a new prop called bathPath which defaults to the current directory the app launches from initially, or respecting the `<base href="..." />` tag's value (both of which document.baseURI resolve to if set / not set). This PR then uses this to lob off the 1st part of the detected pathname to ensure that the baseURI is not required in the routes defined. This allows for links to be relative (`<a href="whatever-route">`) or full reference (`<a href="https://domainname/path/here/yet-route-is-set-here">` or `<a href="/path/here/whatever-route">`)