### PR TITLE
adds timeout for Lit2 compatibility

### DIFF
--- a/lit-element-router.js
+++ b/lit-element-router.js
@@ -118,8 +118,8 @@ export function outlet(base) {
 
         attributeChangedCallback(...args) {
             super.attributeChangedCallback(...args);
-
-            args.some(arg => arg === 'active-route') && this.outlet();
+            setTimeout(() => {
+                args.some(arg => arg === 'active-route') && this.outlet()});
         }
 
         connectedCallback(...args) {


### PR DESCRIPTION
Fixes `lit-element-router.js:137 Uncaught TypeError: Cannot read properties of null (reading 'querySelectorAll')    at HTMLElement.outlet` error when upgrading to Lit 2.0